### PR TITLE
Allow usage with Predis 1 versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "~8.1.0 || ~8.2.0",
-        "predis/predis": "^2.1",
+        "predis/predis": "^1.1 || ^2.1",
         "psr/log": "^3.0",
         "psr/event-dispatcher": "^1.0",
         "react/event-loop": "^1.3",
@@ -53,7 +53,8 @@
             "php": "8.1.99"
         },
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/package-versions-deprecated": true
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "~8.1.0 || ~8.2.0",
-        "predis/predis": "^1.1 || ^2.1",
+        "predis/predis": "^1.1.10 || ^2.1",
         "psr/log": "^3.0",
         "psr/event-dispatcher": "^1.0",
         "react/event-loop": "^1.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1418eb8f376b4d99e4cd1d0b888ca24f",
+    "content-hash": "58a12ce747fc8d54e0785e116ef91cd6",
     "packages": [
         {
             "name": "dragonmantank/cron-expression",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "75c13d566c17fa0b180e78714bbc7712",
+    "content-hash": "1418eb8f376b4d99e4cd1d0b888ca24f",
     "packages": [
         {
             "name": "dragonmantank/cron-expression",
@@ -4249,5 +4249,5 @@
     "platform-overrides": {
         "php": "8.1.99"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
As a consumer, the API has not changed, so we can safely use v1 releases.
This is necessary, as cache/predis-adapter is still on v1.
