### PR TITLE
Allow v1 and v2 releases of psr/log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": "~8.1.0 || ~8.2.0",
         "predis/predis": "^1.1.10 || ^2.1",
-        "psr/log": "^3.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "psr/event-dispatcher": "^1.0",
         "react/event-loop": "^1.3",
         "symfony/console": "^6.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "58a12ce747fc8d54e0785e116ef91cd6",
+    "content-hash": "4b3ab29c251505f276e9bd50beeecc9a",
     "packages": [
         {
             "name": "dragonmantank/cron-expression",


### PR DESCRIPTION
Consumer API of psr/log has not changed, so allow usage with any version.
