### PR TITLE
Allow configuring list of halt signals for commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,3 +263,39 @@ directory=/var/www
 numprocs=1
 redirect_stderr=true
 ```
+
+## Configuration
+
+The following configuration can be consumed via the `config` service:
+
+```php
+return [
+    'redis-task-queue' => [
+        'mappers' => [
+            // Class names of mapper services that can map event types for serialization
+        ],
+        // Float seconds interval between task runner invocations
+        'task_runner_interval' => 1.0,
+        'signals' => [
+            // Integer signals which indicate the task or cron runner should terminate.
+            // In some cases, you may not be able to listen to SIGKILL
+            // (e.g. running under a non-privileged user in supervisord)
+            SIGKILL,
+            SIGINT,
+            SIGTERM,
+        ],
+    ],
+    'cron' => [
+        'jobs' => [
+            /* Job definitions.
+             * These are each arrays, and can have a named index or not.
+             * Each has the following structure:
+             * [
+             *     'schedule' => '* * * * *', // valid cron schedule string
+             *     'task'     => '{"__type": "...", ...}' // JSON serialization of task to run
+             * ]
+             */
+        ],
+    ],
+];
+```

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -25,4 +25,8 @@
         <exclude-pattern>src/Exception/*.php</exclude-pattern>
         <exclude-pattern>src/Mapper/Exception/*.php</exclude-pattern>
     </rule>
+
+    <rule ref="WebimpressCodingStandard.NamingConventions.Interface.Suffix">
+        <exclude-pattern>src/Command/AllowedSignals.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.7.7@e028ba46ba0d7f9a78bc3201c251e137383e145f">
+<files psalm-version="5.8.0@9cf4f60a333f779ad3bc704a555920e81d4fdcda">
+  <file src="src/Command/CronRunnerFactory.php">
+    <ArgumentTypeCoercion>
+      <code>$signalsToRegister</code>
+    </ArgumentTypeCoercion>
+    <MixedAssignment>
+      <code>$config</code>
+    </MixedAssignment>
+  </file>
   <file src="src/Command/TaskRunnerFactory.php">
+    <ArgumentTypeCoercion>
+      <code>$signalsToRegister</code>
+    </ArgumentTypeCoercion>
     <MixedAssignment>
       <code>$config</code>
     </MixedAssignment>

--- a/src/Command/AllowedSignals.php
+++ b/src/Command/AllowedSignals.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phly\RedisTaskQueue\Command;
+
+use const SIGINT;
+use const SIGKILL;
+use const SIGTERM;
+
+interface AllowedSignals
+{
+    /** @psalm-var list<int> */
+    public const DEFAULT_SIGNAL_LIST = [SIGINT, SIGKILL, SIGTERM];
+}

--- a/src/Command/CronRunner.php
+++ b/src/Command/CronRunner.php
@@ -10,13 +10,15 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class CronRunner extends Command
+final class CronRunner extends Command implements AllowedSignals
 {
     use LoopSignalsTrait;
 
     public function __construct(
         private Dispatcher $dispatcher,
         private LoopInterface $loop,
+        /** @psalm-var list<int> */
+        private readonly array $signalsToRegister = self::DEFAULT_SIGNAL_LIST,
     ) {
         parent::__construct();
     }
@@ -30,7 +32,7 @@ final class CronRunner extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->registerTerminationSignals($this->loop, $output);
+        $this->registerTerminationSignals($this->signalsToRegister, $this->loop, $output);
         $this->registerCronHandler($output);
 
         $output->writeln('<info>Starting cron runner</info>');

--- a/src/Command/CronRunnerFactory.php
+++ b/src/Command/CronRunnerFactory.php
@@ -8,7 +8,10 @@ use Phly\RedisTaskQueue\Cron\Dispatcher;
 use Psr\Container\ContainerInterface;
 use React\EventLoop\LoopInterface;
 
+use function array_filter;
 use function assert;
+use function in_array;
+use function is_array;
 
 final class CronRunnerFactory
 {
@@ -20,6 +23,19 @@ final class CronRunnerFactory
         $loop = $container->get(LoopInterface::class);
         assert($loop instanceof LoopInterface);
 
-        return new CronRunner($dispatcher, $loop);
+        $config = $container->get('config');
+        assert(is_array($config));
+
+        $config = $config['redis-task-queue'] ?? [];
+        assert(is_array($config));
+
+        $signalsToRegister = $config['signals'] ?? TaskRunner::DEFAULT_SIGNAL_LIST;
+        assert(is_array($signalsToRegister));
+        $signalsToRegister = array_filter(
+            $signalsToRegister,
+            fn (int $signal) => in_array($signal, CronRunner::DEFAULT_SIGNAL_LIST, true)
+        );
+
+        return new CronRunner($dispatcher, $loop, $signalsToRegister);
     }
 }

--- a/src/Command/TaskRunner.php
+++ b/src/Command/TaskRunner.php
@@ -14,7 +14,7 @@ use Throwable;
 
 use function sprintf;
 
-final class TaskRunner extends Command
+final class TaskRunner extends Command implements AllowedSignals
 {
     use LoopSignalsTrait;
 
@@ -23,6 +23,8 @@ final class TaskRunner extends Command
         private EventDispatcherInterface $dispatcher,
         private LoopInterface $loop,
         private readonly float $interval = 1.0,
+        /** @psalm-var list<int> */
+        private readonly array $signalsToRegister = self::DEFAULT_SIGNAL_LIST,
     ) {
         parent::__construct();
     }
@@ -35,7 +37,7 @@ final class TaskRunner extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->registerTerminationSignals($this->loop, $output);
+        $this->registerTerminationSignals($this->signalsToRegister, $this->loop, $output);
         $this->registerTaskHandler($this->loop, $output);
         $output->writeln('<info>Starting task runnner</info>');
         $this->loop->run();

--- a/src/Command/TaskRunnerFactory.php
+++ b/src/Command/TaskRunnerFactory.php
@@ -9,7 +9,9 @@ use Psr\Container\ContainerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use React\EventLoop\LoopInterface;
 
+use function array_filter;
 use function assert;
+use function in_array;
 use function is_array;
 use function is_numeric;
 
@@ -35,11 +37,19 @@ final class TaskRunnerFactory
         $interval = $config['task_runner_interval'] ?? 1.0;
         assert(is_numeric($interval));
 
+        $signalsToRegister = $config['signals'] ?? TaskRunner::DEFAULT_SIGNAL_LIST;
+        assert(is_array($signalsToRegister));
+        $signalsToRegister = array_filter(
+            $signalsToRegister,
+            fn (int $signal) => in_array($signal, TaskRunner::DEFAULT_SIGNAL_LIST, true)
+        );
+
         return new TaskRunner(
             $queue,
             $dispatcher,
             $loop,
             (float) $interval,
+            $signalsToRegister,
         );
     }
 }


### PR DESCRIPTION
The default set of signals can be problematic when running as a non-privileged user in supervisord. This patch allows users to configure the list of signals they want to register halt handlers for.

The configuration is:

```php
return [
    'redis-task-queue' => [
        'signals' => [SIGTERM, SIGINT],
    ],
];
```
